### PR TITLE
過去にいいねしたユーザに新規レビューをメール通知する機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development do
   gem 'listen', '~> 3.3'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+  gem 'letter_opener_web', '~> 1.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,14 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    launchy (2.5.2)
+      addressable (~> 2.8)
+    letter_opener (1.8.1)
+      launchy (>= 2.2, < 3)
+    letter_opener_web (1.4.1)
+      actionmailer (>= 3.2)
+      letter_opener (~> 1.0)
+      railties (>= 3.2)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -307,6 +315,7 @@ DEPENDENCIES
   high_voltage
   jbuilder (~> 2.7)
   kaminari (~> 1.2.1)
+  letter_opener_web (~> 1.0)
   listen (~> 3.3)
   mysql2
   net-imap

--- a/app/controllers/user/contents_controller.rb
+++ b/app/controllers/user/contents_controller.rb
@@ -46,11 +46,14 @@ class User::ContentsController < ApplicationController
   
     if @content.save
       @content.save_tag(tag_list)
+      send_message_service = SendMessageService.new(@content)
+      send_message_service.send_message_to_favorited_users
       flash[:notice] = "投稿しました"
       redirect_to contents_path(sort: 'newest')
     else
       render :new
     end
+    
   end
 
   def edit

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,5 @@
+class ApplicationMailer < ActionMailer::Base
+  default from: 'Totono-ru@totono-ru.com'
+  layout 'mailer'
+end
+

--- a/app/mailers/favorited_user_mailer.rb
+++ b/app/mailers/favorited_user_mailer.rb
@@ -1,0 +1,8 @@
+
+class FavoritedUserMailer < ApplicationMailer
+  def new_content_message_email(user, content)
+    @user = user
+    @content = content
+    mail(to: @user.email, subject: '【ととの〜る】いいねしたユーザが新しいレビューを投稿しました!')
+  end
+end

--- a/app/mailers/favorited_user_mailer.rb
+++ b/app/mailers/favorited_user_mailer.rb
@@ -1,4 +1,3 @@
-
 class FavoritedUserMailer < ApplicationMailer
   def new_content_message_email(user, content)
     @user = user

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -55,4 +55,5 @@ class Content < ApplicationRecord
           self.tags << content_tag
        end
     end
+    aa
 end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -55,5 +55,23 @@ class Content < ApplicationRecord
           self.tags << content_tag
        end
     end
-    aa
+    
+        
+    # 新しいレビューがデータベースに保存された後に以下のメソッドが実行する。（コールバック）
+    after_create :send_message_to_favorited_users
+    
+    private
+    
+    # いいねしたユーザのIDリストを取得するメソッド
+    def send_message_to_favorited_users
+      favorited_users = Favorite.where(content_id: self.user.contents.pluck(:id)).pluck(:user_id)
+      favorited_users.each do |user_id|
+        user = User.find(user_id)
+        # 投稿した本人にメールを送信しない
+        unless user_id == self.user.id
+          FavoritedUserMailer.new_content_message_email(user, self).deliver_now
+        end
+      end
+    end
+
 end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -64,22 +64,33 @@ class Content < ApplicationRecord
        end
     end
     
+    # def send_message_to_favorited_users
+    #   content_user = self.user
+    #   favorited_users = Favorite.where(content_id: content_user.contents.pluck(:id)).pluck(:user_id).uniq
+    #   favorited_users.each do |user_id|
+    #     user = User.find(user_id)
+    #     # 投稿した本人にメールを送信しない
+    #     unless user_id == content_user.id
+    #       FavoritedUserMailer.new_content_message_email(user, self).deliver_now
+    #     end
+    #   end
+    # end
+
+    
         
-    # 新しいレビューがデータベースに保存された後に以下のメソッドが実行する。（コールバック）
-    after_create :send_message_to_favorited_users
+    # # 新しいレビューがデータベースに保存された後に以下のメソッドが実行する。（コールバック）
+    # after_create :send_message_to_favorited_users
     
-    private
-    
-    # いいねしたユーザのIDリストを取得するメソッド
-    def send_message_to_favorited_users
-      favorited_users = Favorite.where(content_id: self.user.contents.pluck(:id)).pluck(:user_id).uniq
-      favorited_users.each do |user_id|
-        user = User.find(user_id)
-        # 投稿した本人にメールを送信しない
-        unless user_id == self.user.id
-          FavoritedUserMailer.new_content_message_email(user, self).deliver_now
-        end
-      end
-    end
+    # # いいねしたユーザのIDリストを取得するメソッド
+    # def send_message_to_favorited_users
+    #   favorited_users = Favorite.where(content_id: self.user.contents.pluck(:id)).pluck(:user_id).uniq
+    #   favorited_users.each do |user_id|
+    #     user = User.find(user_id)
+    #     # 投稿した本人にメールを送信しない
+    #     unless user_id == self.user.id
+    #       FavoritedUserMailer.new_content_message_email(user, self).deliver_now
+    #     end
+    #   end
+    # end
 
 end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -64,7 +64,7 @@ class Content < ApplicationRecord
     
     # いいねしたユーザのIDリストを取得するメソッド
     def send_message_to_favorited_users
-      favorited_users = Favorite.where(content_id: self.user.contents.pluck(:id)).pluck(:user_id)
+      favorited_users = Favorite.where(content_id: self.user.contents.pluck(:id)).pluck(:user_id).uniq
       favorited_users.each do |user_id|
         user = User.find(user_id)
         # 投稿した本人にメールを送信しない

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -64,22 +64,11 @@ class Content < ApplicationRecord
        end
     end
     
-    # def send_message_to_favorited_users
-    #   content_user = self.user
-    #   favorited_users = Favorite.where(content_id: content_user.contents.pluck(:id)).pluck(:user_id).uniq
-    #   favorited_users.each do |user_id|
-    #     user = User.find(user_id)
-    #     # 投稿した本人にメールを送信しない
-    #     unless user_id == content_user.id
-    #       FavoritedUserMailer.new_content_message_email(user, self).deliver_now
-    #     end
-    #   end
-    # end
-
-    
         
     # # 新しいレビューがデータベースに保存された後に以下のメソッドが実行する。（コールバック）
     # after_create :send_message_to_favorited_users
+    
+    # private
     
     # # いいねしたユーザのIDリストを取得するメソッド
     # def send_message_to_favorited_users

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -8,6 +8,14 @@ class Content < ApplicationRecord
     # 画像投稿機能を追加
     has_one_attached :review_image
     
+    def get_review_image
+      unless review_image.attached?
+        file_path = Rails.root.join('app/assets/images/no_image.jpg')
+        profile_image.attach(io: File.open(file_path), filename: 'default-image.jpg', content_type: 'image/jpeg')
+      end
+      review_image
+    end
+    
     validates :title,presence:true, length: { minimum: 3, maximum: 35 }
     validates :text ,presence:true
     

--- a/app/services/send_message_service.rb
+++ b/app/services/send_message_service.rb
@@ -1,0 +1,16 @@
+class SendMessageService
+  def initialize(content)
+    @content = content
+  end
+  
+  def send_message_to_favorited_users
+    favorited_users = Favorite.where(content_id: @content.user.contents.pluck(:id)).pluck(:user_id).uniq
+    favorited_users.each do |user_id|
+      user = User.find(user_id)
+      # 投稿した本人にメールを送信しない
+      unless user_id == @content.user.id
+        FavoritedUserMailer.new_content_message_email(user, @content).deliver_now
+      end
+    end
+  end
+end

--- a/app/views/favorited_user_mailer/new_content_message_email.html.erb
+++ b/app/views/favorited_user_mailer/new_content_message_email.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>	
+<html>	
+  <head>	
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />	
+  </head>	
+  <body>	
+    <h1> <%= @user.name %> 様</h1>	
+    <h3>いつも「ととの〜る」をご利用いただきありがとうございます。</h3>	
+    <p><%= @content.user.name %> さんが新しいレビューを投稿しました！</p>	
+    <p>詳細な内容を見るには以下のリンクをクリックしてください。</p>	
+    <p>レビュータイトル: <%= @content.title %></p>	
+    <a href="<%= content_url(@content) %>">新しいレビューを見る</a>	
+    <br>	
+    <p>以上になります。</p>	
+    <p>今後とも「ととの〜る」をご愛顧いただきますよう、よろしくお願いいたします。</p>	
+  </body>	
+</html>

--- a/app/views/user/contents/_show.html.erb
+++ b/app/views/user/contents/_show.html.erb
@@ -69,7 +69,7 @@
               <div class="review_image_modal" id="reviewImageModal">
                 <img id="modalImage">
               </div>
-              <%= image_tag content.review_image, class: "review_image clickable" %>
+              <%= image_tag content.get_review_image, class: "review_image clickable" %>
             <% else %>
               <p>フォトはありません</p>
             <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,9 +73,5 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
-  config.action_mailer.delivery_method = :letter_opener_web
-  config.action_mailer.perform_deliveries = true
-  config.action_mailer.default_url_options = { host: '9324485c1f1c4799a4216495e8c8ef58.vfs.cloud9.ap-northeast-1.amazonaws.com', protocol: 'https' }
-
   config.hosts.clear
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,5 +73,9 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.default_url_options = { host: '9324485c1f1c4799a4216495e8c8ef58.vfs.cloud9.ap-northeast-1.amazonaws.com', protocol: 'https' }
+
   config.hosts.clear
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,6 +73,9 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.default_url_options = { host: '9324485c1f1c4799a4216495e8c8ef58.vfs.cloud9.ap-northeast-1.amazonaws.com', protocol: 'https' }
 
   config.hosts.clear
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Comment, type: :model do
-  describe 'commentモデル#how_long_agoメソッドのテスト' do
-    let!(:user) { create(:user) }
-    let!(:content) { create(:content) }
+  describe 'commentモデル#how_long_ago テスト' do
+    let(:user) { create(:user) }
+    let(:content) { create(:content) }
 
     it '1時間以内の場合、分単位で表示されること' do
       comment = create(:comment, user: user, content: content, created_at: Time.now - 30.minutes)

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -2,6 +2,37 @@
 
 require 'rails_helper'
 
-describe 'モデルのテスト' do
-
+RSpec.describe Content, type: :model do
+  describe '#send_message_to_favorited_users のテスト' do
+    let(:user) { create(:user) }
+    let(:content) { create(:content, user: user) }
+    let(:send_message_service) { SendMessageService.new(content) }
+    
+    it 'いいねされたユーザにメールを送信すること' do
+      # テスト用のいいねしたユーザと投稿を作成
+      favorited_user = create(:user)
+      create(:favorite, user: favorited_user, content: content)
+      
+      # FavoritedUserMailer が適切に呼び出されることをモックする
+      # テストの中で実際にはメールを送信せずに、そのメール送信処理が正しく呼び出されたことを確認するための手法
+      mailer_instance = double('FavoritedUserMailer')
+      expect(FavoritedUserMailer).to receive(:new_content_message_email).with(favorited_user, content).and_return(mailer_instance)
+      expect(mailer_instance).to receive(:deliver_now)
+      # テスト内で実際にメールを送信する代わりに、モックオブジェクトを使用して制御している
+      
+      # テスト対象のメソッドを呼び出す
+      send_message_service.send_message_to_favorited_users
+    end
+    
+    it '投稿者にはメールを送信しないこと' do
+      # 投稿者にいいねがある状態を作成
+      create(:favorite, user: user, content: content)
+      
+      # FavoritedUserMailer が呼び出されないことを確認する
+      expect(FavoritedUserMailer).not_to receive(:new_content_message_email)
+      
+      # テスト対象のメソッドを呼び出す
+      send_message_service.send_message_to_favorited_users
+    end
+  end
 end


### PR DESCRIPTION
### 概要
あるユーザが新規でレビューを投稿した時に、そのユーザの過去のレビューに対して「いいね」していたユーザに、メールで「ユーザが新しいレビューを投稿した」ことを、お知らせする機能を作成しました。

### 実装画面
![Aug-17-2023 18-10-41](https://github.com/PB-193/Totono-ru/assets/127069516/40ad94b8-3aa2-4601-81d4-fcc8c9fab6c7)
